### PR TITLE
xgrpc: add ClientFilter and ServerFilter options

### DIFF
--- a/xgrpc/grpc.go
+++ b/xgrpc/grpc.go
@@ -24,6 +24,19 @@ func parseMethod(fullMethod string) (string, string, string, bool) {
 	return subs[1], subs[2], subs[3], true
 }
 
+// filter can be used for filtering a package, a service, or a method from being observed.
+type filter struct {
+	pkg     string
+	service string
+	method  string
+}
+
+func (f *filter) matches(pkg, service, method string) bool {
+	return (f.pkg == pkg && f.service == "" && f.method == "") ||
+		(f.pkg == pkg && f.service == service && f.method == "") ||
+		(f.pkg == pkg && f.service == service && f.method == method)
+}
+
 type xServerStream struct {
 	grpc.ServerStream
 	context context.Context

--- a/xgrpc/grpc_test.go
+++ b/xgrpc/grpc_test.go
@@ -49,6 +49,54 @@ func TestParseMethod(t *testing.T) {
 	}
 }
 
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		name                 string
+		filter               filter
+		pkg, service, method string
+		expectedMatch        bool
+	}{
+		{
+			"EmptyFilter",
+			filter{"", "", ""},
+			"testPB", "Manager", "Ping",
+			false,
+		},
+		{
+			"MatchPackage",
+			filter{"testPB", "", ""},
+			"testPB", "Manager", "Ping",
+			true,
+		},
+		{
+			"MatchService",
+			filter{"testPB", "Manager", ""},
+			"testPB", "Manager", "Ping",
+			true,
+		},
+		{
+			"MatchMethod",
+			filter{"testPB", "Manager", "Ping"},
+			"testPB", "Manager", "Ping",
+			true,
+		},
+		{
+			"NoMatch",
+			filter{"testPB", "", "Ping"},
+			"testPB", "Manager", "Ping",
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match := tc.filter.matches(tc.pkg, tc.service, tc.method)
+
+			assert.Equal(t, tc.expectedMatch, match)
+		})
+	}
+}
+
 func TestXServerStream(t *testing.T) {
 	ctx1 := context.WithValue(context.Background(), contextKey("user-id"), "1111")
 	ctx2 := context.WithValue(ctx1, contextKey("trace-id"), "aaaa")

--- a/xgrpc/interceptor_client.go
+++ b/xgrpc/interceptor_client.go
@@ -69,6 +69,7 @@ func ClientTracing(tracer opentracing.Tracer) ClientInterceptorOption {
 // If you only specify the pkg, all methods in all services in that package will be filtered.
 // If you only specify the pkg and the service, all methods in that service in that package will be filtered.
 // If you specify the pkg, the service, and the method, only that method in that service in that package will be filtered.
+// You can use this option multiple times for filtering different packages, services, or methods.
 func ClientFilter(pkg, service, method string) ClientInterceptorOption {
 	return func(i *ClientInterceptor) {
 		i.filters = append(i.filters, filter{

--- a/xgrpc/interceptor_client.go
+++ b/xgrpc/interceptor_client.go
@@ -28,6 +28,7 @@ const (
 // ClientInterceptor is a gRPC client interceptor for logging, metrics, and tracing.
 type ClientInterceptor struct {
 	name    string
+	filters []filter
 	logger  *log.Logger
 	metrics *metrics.RequestMetrics
 	tracer  opentracing.Tracer
@@ -64,9 +65,27 @@ func ClientTracing(tracer opentracing.Tracer) ClientInterceptorOption {
 	}
 }
 
+// ClientFilter is the option for excluding a package, a service, or a method from being observed.
+// If you only specify the pkg, all methods in all services in that package will be filtered.
+// If you only specify the pkg and the service, all methods in that service in that package will be filtered.
+// If you specify the pkg, the service, and the method, only that method in that service in that package will be filtered.
+func ClientFilter(pkg, service, method string) ClientInterceptorOption {
+	return func(i *ClientInterceptor) {
+		i.filters = append(i.filters, filter{
+			pkg:     pkg,
+			service: service,
+			method:  method,
+		})
+	}
+}
+
 // NewClientInterceptor creates a new instance of gRPC client interceptor.
 func NewClientInterceptor(name string, opts ...ClientInterceptorOption) *ClientInterceptor {
-	ci := &ClientInterceptor{name: name}
+	ci := &ClientInterceptor{
+		name:    name,
+		filters: []filter{},
+	}
+
 	for _, opt := range opts {
 		opt(ci)
 	}
@@ -129,6 +148,13 @@ func (i *ClientInterceptor) UnaryInterceptor(ctx context.Context, fullMethod str
 	pkg, service, method, ok := parseMethod(fullMethod)
 	if !ok {
 		return invoker(ctx, method, req, res, cc, opts...)
+	}
+
+	// Apply filters if any
+	for _, f := range i.filters {
+		if f.matches(pkg, service, method) {
+			return invoker(ctx, method, req, res, cc, opts...)
+		}
 	}
 
 	// Get request id from context
@@ -220,6 +246,13 @@ func (i *ClientInterceptor) StreamInterceptor(ctx context.Context, desc *grpc.St
 	pkg, service, method, ok := parseMethod(fullMethod)
 	if !ok {
 		return streamer(ctx, desc, cc, method, opts...)
+	}
+
+	// Apply filters if any
+	for _, f := range i.filters {
+		if f.matches(pkg, service, method) {
+			return streamer(ctx, desc, cc, method, opts...)
+		}
 	}
 
 	// Get request id from context

--- a/xgrpc/interceptor_server.go
+++ b/xgrpc/interceptor_server.go
@@ -35,6 +35,7 @@ const (
 
 // ServerInterceptor is a gRPC server interceptor for logging, metrics, and tracing.
 type ServerInterceptor struct {
+	filters []filter
 	logger  *log.Logger
 	metrics *metrics.RequestMetrics
 	tracer  opentracing.Tracer
@@ -71,9 +72,26 @@ func ServerTracing(tracer opentracing.Tracer) ServerInterceptorOption {
 	}
 }
 
+// ServerFilter is the option for excluding a package, a service, or a method from being observed.
+// If you only specify the pkg, all methods in all services in that package will be filtered.
+// If you only specify the pkg and the service, all methods in that service in that package will be filtered.
+// If you specify the pkg, the service, and the method, only that method in that service in that package will be filtered.
+func ServerFilter(pkg, service, method string) ServerInterceptorOption {
+	return func(i *ServerInterceptor) {
+		i.filters = append(i.filters, filter{
+			pkg:     pkg,
+			service: service,
+			method:  method,
+		})
+	}
+}
+
 // NewServerInterceptor creates a new instance of gRPC server interceptor.
 func NewServerInterceptor(opts ...ServerInterceptorOption) *ServerInterceptor {
-	si := &ServerInterceptor{}
+	si := &ServerInterceptor{
+		filters: []filter{},
+	}
+
 	for _, opt := range opts {
 		opt(si)
 	}
@@ -128,6 +146,13 @@ func (i *ServerInterceptor) UnaryInterceptor(ctx context.Context, req interface{
 	pkg, service, method, ok := parseMethod(info.FullMethod)
 	if !ok {
 		return handler(ctx, req)
+	}
+
+	// Apply filters if any
+	for _, f := range i.filters {
+		if f.matches(pkg, service, method) {
+			return handler(ctx, req)
+		}
 	}
 
 	// Get request metadata
@@ -223,6 +248,13 @@ func (i *ServerInterceptor) StreamInterceptor(srv interface{}, ss grpc.ServerStr
 	pkg, service, method, ok := parseMethod(info.FullMethod)
 	if !ok {
 		return handler(srv, ss)
+	}
+
+	// Apply filters if any
+	for _, f := range i.filters {
+		if f.matches(pkg, service, method) {
+			return handler(srv, ss)
+		}
 	}
 
 	// Get request metadata

--- a/xgrpc/interceptor_server.go
+++ b/xgrpc/interceptor_server.go
@@ -76,6 +76,7 @@ func ServerTracing(tracer opentracing.Tracer) ServerInterceptorOption {
 // If you only specify the pkg, all methods in all services in that package will be filtered.
 // If you only specify the pkg and the service, all methods in that service in that package will be filtered.
 // If you specify the pkg, the service, and the method, only that method in that service in that package will be filtered.
+// You can use this option multiple times for filtering different packages, services, or methods.
 func ServerFilter(pkg, service, method string) ServerInterceptorOption {
 	return func(i *ServerInterceptor) {
 		i.filters = append(i.filters, filter{


### PR DESCRIPTION
## Description

Adding the following new options to `xgrpc` package:

  - [x] `ClientFilter`: filtering certain package, services, or methods from being observed
  - [x] `ServerFilter`: filtering certain package, services, or methods from being observed

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
